### PR TITLE
Avoid running as root inside container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,13 @@ RUN stack install --resolver=$RESOLVER \
     config-ini-0.2.4.0 \
     data-clist-0.1.2.2 \
     word-wrap-0.4.1 \
-    hledger-lib-1.14 \
-    hledger-1.14.1 \
-    hledger-ui-1.14 \
-    hledger-web-1.14 \
+    hledger-lib-1.14.1 \
+    hledger-1.14.2 \
+    hledger-ui-1.14.1 \
+    hledger-web-1.14.1 \
     hledger-api-1.14 \
-    hledger-diff-0.2.0.14 \
     hledger-iadd-1.3.9 \
-    hledger-interest
+    hledger-interest-1.5.3
 
 FROM debian:stable-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,7 @@ FROM debian:stable-slim
 
 MAINTAINER Dmitry Astapov <dastapov@gmail.com>
 
-RUN apt-get update && apt-get install libgmp10 && rm -rf /var/lib/apt/lists
+RUN apt-get update && apt-get install --yes libgmp10 libtinfo5 && rm -rf /var/lib/apt/lists
 RUN adduser --system --ingroup root hledger
 
 COPY --from=dev /root/.local/bin/hledger* /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
-FROM debian:stable-slim as dev
+FROM haskell as dev
 
-RUN apt-get update
-RUN apt-get install -y curl libtinfo-dev
-RUN (curl -sSL https://get.haskellstack.org/ | sh)
 RUN stack setup --resolver=lts-12
 RUN stack install --resolver=lts-12 \
     cassava-megaparsec-2.0.0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ FROM debian:stable-slim
 MAINTAINER Dmitry Astapov <dastapov@gmail.com>
 
 RUN apt-get update && apt-get install libgmp10 && rm -rf /var/lib/apt/lists
+RUN adduser --system --ingroup root hledger
 
 COPY --from=dev /root/.local/bin/hledger* /usr/bin/
 
@@ -33,5 +34,7 @@ VOLUME /data
 EXPOSE 5000 5001
 
 COPY start.sh /start.sh
+
+USER hledger
 
 CMD ["/start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,8 @@ RUN stack install --resolver=lts-13 \
     config-ini-0.2.4.0 \
     data-clist-0.1.2.2 \
     word-wrap-0.4.1 \
-    hledger-lib-1.13 \
-    hledger-1.13 \
+    hledger-lib-1.13.1 \
+    hledger-1.13.2 \
     hledger-ui-1.13.1 \
     hledger-web-1.13 \
     hledger-api-1.13 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,13 +9,13 @@ RUN stack install --resolver=$RESOLVER \
     config-ini-0.2.4.0 \
     data-clist-0.1.2.2 \
     word-wrap-0.4.1 \
-    hledger-lib-1.13.1 \
-    hledger-1.13.2 \
-    hledger-ui-1.13.1 \
-    hledger-web-1.13 \
-    hledger-api-1.13 \
+    hledger-lib-1.14 \
+    hledger-1.14.1 \
+    hledger-ui-1.14 \
+    hledger-web-1.14 \
+    hledger-api-1.14 \
     hledger-diff-0.2.0.14 \
-    hledger-iadd-1.3.8 \
+    hledger-iadd-1.3.9 \
     hledger-interest
 
 FROM debian:stable-slim

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM haskell as dev
+FROM haskell:latest as dev
 
-RUN stack setup --resolver=lts-13
-RUN stack install --resolver=lts-13 \
+ENV RESOLVER lts-13.8
+
+RUN stack setup --resolver=$RESOLVER
+RUN stack install --resolver=$RESOLVER \
     brick-0.46 \
     text-zipper-0.10.1 \
     config-ini-0.2.4.0 \
@@ -13,7 +15,8 @@ RUN stack install --resolver=lts-13 \
     hledger-web-1.13 \
     hledger-api-1.13 \
     hledger-diff-0.2.0.14 \
-    hledger-iadd-1.3.8
+    hledger-iadd-1.3.8 \
+    hledger-interest
 
 FROM debian:stable-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM haskell as dev
 
-RUN stack setup --resolver=lts-12
-RUN stack install --resolver=lts-12 \
-    cassava-megaparsec-2.0.0 \
-    config-ini-0.2.3.0 \
-    easytest-0.2.1 \
-    megaparsec-7.0.2 \
-    hledger-lib-1.12 \
-    hledger-1.12 \
-    hledger-ui-1.12 \
-    hledger-web-1.12 \
-    hledger-api-1.12 \
+RUN stack setup --resolver=lts-13
+RUN stack install --resolver=lts-13 \
+    brick-0.46 \
+    text-zipper-0.10.1 \
+    config-ini-0.2.4.0 \
+    data-clist-0.1.2.2 \
+    word-wrap-0.4.1 \
+    hledger-lib-1.13 \
+    hledger-1.13 \
+    hledger-ui-1.13.1 \
+    hledger-web-1.13 \
+    hledger-api-1.13 \
     hledger-diff-0.2.0.14 \
-    hledger-iadd-1.3.7
+    hledger-iadd-1.3.8
 
 FROM debian:stable-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,5 +36,6 @@ EXPOSE 5000 5001
 COPY start.sh /start.sh
 
 USER hledger
+WORKDIR /data
 
 CMD ["/start.sh"]

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docker image for hledger 1.14 and associated tools
+# Docker image for hledger 1.14.2 and associated tools
 
 This docker image provides [hledger](http://hledger.org/), the plain text accounting software, and
 associated tools:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docker image for hledger 1.12 and associated tools
+# Docker image for hledger 1.13 and associated tools
 
 This docker image provides [hledger](http://hledger.org/), the plain text accounting software, and
 associated tools:

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Docker image for hledger 1.13 and associated tools
+# Docker image for hledger 1.14 and associated tools
 
 This docker image provides [hledger](http://hledger.org/), the plain text accounting software, and
 associated tools:

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ associated tools:
 By default, container will start hledger-web on port 5000 and hledger-api on port 5001, both of them reading journal `hledger.journal` from volume `data`, so assuming your journal is in `~/journals/all.journal`, you can run:
 
 ```
-docker run --rm -d -e HLEDGER_JOURNAL_FILE=/data/all.journal -v "$HOME/journals:/data" -p 5000:5000 -p 5001:5001 dastapov/hledger
+docker run --rm -d -e HLEDGER_JOURNAL_FILE=/data/all.journal -v "$HOME/journals:/data" -p 5000:5000 -p 5001:5001 --user $(id --user) dastapov/hledger
 ```
 
 and navigate to `http://localhost:5000` for hledger-web and URLs like `http://localhost:5001/api/v1/accounts` for hledger-api.
 
 If you have LEDGER_FILE environmed variable defined already, you can try:
 ```
-docker run --rm -d -e HLEDGER_JOURNAL_FILE=/data/$(basename $LEDGER_FILE) -v "$(dirname $LEDGER_FILE):/data" -p 5000:5000 -p 5001:5001 dastapov/hledger
+docker run --rm -d -e HLEDGER_JOURNAL_FILE=/data/$(basename $LEDGER_FILE) -v "$(dirname $LEDGER_FILE):/data" -p 5000:5000 -p 5001:5001 --user $(id --user) dastapov/hledger
 ```
 
 Github repo contains helper script that simplifies invocation:
@@ -58,7 +58,7 @@ providing alternative start command to `docker run`.
 
 You can just drop into a shell in the container and run hledger there (remember to include `-it`):
 ```
-docker run --rm -it -v "$HOME/hledger-data:/data" dastapov/hledger bash
+docker run --rm -it -v "$HOME/hledger-data:/data" --user $(id --user) dastapov/hledger bash
 ```
 
 Github repo contains helper script that simplifies invocation:
@@ -71,7 +71,7 @@ Github repo contains helper script that simplifies invocation:
 You can use `docker run` to invoke `hledger` directly:
 
 ```
-docker run --rm -v "$HOME/hledger-data:/data" dastapov/hledger hledger -f /data/hledger.journal stats
+docker run --rm -v "$HOME/hledger-data:/data" --user $(id --user) dastapov/hledger hledger -f /data/hledger.journal stats
 ```
 
 Make sure you provide `--rm` argument to `docker run`, otherwise your containers will be kept in the container

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ If you have LEDGER_FILE environmed variable defined already, you can try:
 docker run --rm -d -e HLEDGER_JOURNAL_FILE=/data/$(basename $LEDGER_FILE) -v "$(dirname $LEDGER_FILE):/data" -p 5000:5000 -p 5001:5001 dastapov/hledger
 ```
 
+Github repo contains helper script that simplifies invocation:
+```
+./run.sh ~/journals/all.journal web
+```
+
 #### Environment variables
 
  * `HLEDGER_JOURNAL_FILE`
@@ -46,7 +51,7 @@ docker run --rm -d -e HLEDGER_JOURNAL_FILE=/data/$(basename $LEDGER_FILE) -v "$(
  * `HLEDGER_RULES_FILE`
    * CSV conversion rules file (default: /data/hledger.rules)
 
-### hledger cli
+### hledger cli in the shell
 
 You can use this image to run command-line version of hledger (or hledger-iadd, hledger-ui, ...) by
 providing alternative start command to `docker run`.
@@ -56,7 +61,14 @@ You can just drop into a shell in the container and run hledger there (remember 
 docker run --rm -it -v "$HOME/hledger-data:/data" dastapov/hledger bash
 ```
 
-Alternatively, you can replace `bash` with a suitable invocation of `hledger`:
+Github repo contains helper script that simplifies invocation:
+```
+./run.sh ~/journals/all.journal bash
+```
+
+### hledger cli via docker run
+
+You can use `docker run` to invoke `hledger` directly:
 
 ```
 docker run --rm -v "$HOME/hledger-data:/data" dastapov/hledger hledger -f /data/hledger.journal stats
@@ -65,6 +77,12 @@ docker run --rm -v "$HOME/hledger-data:/data" dastapov/hledger hledger -f /data/
 Make sure you provide `--rm` argument to `docker run`, otherwise your containers will be kept in the container
 registry even after you are done with them, which is probably not what you want.
 
+
+Github repo contains helper script that simplifies invocation:
+```
+./run.sh ~/journals/all.journal hledger [args...]
+```
+ 
 ### Using image for hledger development
 
 You can use the supplied Dockerfile to get yourself an image for hledger development. Build target `dev`
@@ -74,7 +92,7 @@ will get you Debian-based image with `stack` and all the build dependencies of `
 docker image build --tag hledger-dev --target dev .
 ```
 
-Alternatively, you can use pre-built image via:
+Alternatively, you can use pre-built image via `latest-dev` or `VERSION-dev` tags:
 ```
 docker run --rm -it -v "$HOME/hledger-data:/data" dastapov/hledger:latest-dev bash
 ```

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+v=1.13
+docker image pull haskell
+docker image build -t dastapov/hledger:latest-dev -t dastapov/hledger:${v}-dev --target dev .
+docker image build -t dastapov/hledger:latest -t dastapov/hledger:${v} .
+
+docker image push dastapov/hledger:${v}-dev
+docker image push dastapov/hledger:latest-dev
+docker image push dastapov/hledger:${v}
+docker image push dastapov/hledger:latest

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-v=1.14
+v=1.14.2
 docker image pull haskell
 docker image build -t dastapov/hledger:latest-dev -t dastapov/hledger:${v}-dev --target dev .
 docker image build -t dastapov/hledger:latest -t dastapov/hledger:${v} .

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -e
-v=1.13
+v=1.14
 docker image pull haskell
 docker image build -t dastapov/hledger:latest-dev -t dastapov/hledger:${v}-dev --target dev .
 docker image build -t dastapov/hledger:latest -t dastapov/hledger:${v} .

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -e -o pipefail
+
+function usage() {
+    echo "USAGE: $0 /path/to/hledger.journal [web|bash|hledger [hledger-args]]"
+}
+
+journal=$(readlink -f "$1")
+shift
+[ -f "$journal" ] || { usage; exit 1; }
+dir=$(dirname $journal)
+file=$(basename $journal)
+
+cmd="$1"
+shift
+
+case "$cmd" in
+    web) extra_args=""  ;;
+    bash) extra_args="bash" ;;
+    hledger) extra_args="hledger" ;;
+    *)usage; exit 1 ;;
+esac
+
+docker container run --rm -it --volume "$dir:/data" \
+       --env HLEDGER_FILE_NAME=/data/$file \
+       --env LEDGER_FILE=/data/$file \
+       -p 5000:5000 -p 5001:5001 \
+       hledger $extra_args "$@"

--- a/run.sh
+++ b/run.sh
@@ -25,4 +25,5 @@ docker container run --rm -it --volume "$dir:/data" \
        --env HLEDGER_FILE_NAME=/data/$file \
        --env LEDGER_FILE=/data/$file \
        -p 5000:5000 -p 5001:5001 \
+       --user $(id --user) \
        dastapov/hledger $extra_args "$@"

--- a/run.sh
+++ b/run.sh
@@ -25,4 +25,4 @@ docker container run --rm -it --volume "$dir:/data" \
        --env HLEDGER_FILE_NAME=/data/$file \
        --env LEDGER_FILE=/data/$file \
        -p 5000:5000 -p 5001:5001 \
-       hledger $extra_args "$@"
+       dastapov/hledger $extra_args "$@"


### PR DESCRIPTION
Here is a proposed fix for adept/hledger-docker#2. Processes inside the container now run as a regular user by default, avoiding the security issue of running as root. A few more modifications are needed in order to grant write access to those processes to the journal file mounted under `/data`, e.g. running with the same UID as the current user inside the container.