### PR TITLE
Enable passwordless sudo for hledger user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,10 @@ FROM debian:stable-slim
 
 MAINTAINER Dmitry Astapov <dastapov@gmail.com>
 
-RUN apt-get update && apt-get install --yes libgmp10 libtinfo5 && rm -rf /var/lib/apt/lists
+RUN apt-get update && apt-get install --yes libgmp10 libtinfo5 sudo && rm -rf /var/lib/apt/lists
 RUN adduser --system --ingroup root hledger
+RUN usermod -aG sudo hledger
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 
 COPY --from=dev /root/.local/bin/hledger* /usr/bin/
 


### PR DESCRIPTION
This PR enables passwordless `sudo` usage for the `hledger` user to make installing packages in the container possible again.

Adapted from https://stackoverflow.com/questions/25845538/how-to-use-sudo-inside-a-docker-container

I really have no experience with building Docker images and hope I didn't overlook anything. However, with these changes applied, after running `docker build .` in the repository root and then `docker run -it --rm CONTAINER_ID bash` I am able to `sudo apt-get update` and `sudo apt-get install ...` again.

Fixes #4 