### PR TITLE
allow spaces in the path

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -7,8 +7,8 @@ function usage() {
 
 journal=$(readlink -f "$1") || { usage; exit 1; }
 shift
-dir=$(dirname $journal)
-file=$(basename $journal)
+dir=$(dirname "$journal")
+file=$(basename "$journal")
 
 cmd="$1"
 shift


### PR DESCRIPTION
Putting quotes around "$journal" makes it possible to have spaces when the user specifies the path to the journal file. 